### PR TITLE
Feature/recent endpoint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,9 @@ async fn recent(opt: web::Data<Opt>) -> Result<impl Responder, Error> {
 
     let page = build_recent_html_page(&latest_n_files, base_dir.len() + 1); // + 1 for the dir separator
 
-    Ok(HttpResponse::Ok().body(page))
+    Ok(HttpResponse::Ok()
+        .content_type("text/html; charset=utf-8")
+        .body(page))
 }
 
 fn generate_random_filename(extension: Option<&str>) -> String {


### PR DESCRIPTION
This addresses #2 by creating a /recent endpoint as a html-page. Right now the 5 latest files are shown, this is set by the `n_of_recent_files` variable. It might be neat with having that variable change from a request variable of some sort.

As I mentioned earlier, I'm dipping my toes in Rust and I have not yet finished reading the book. I appreciate any feedback on the code and how you would like to have it structured. What I'm most unsure about is the error handling. If you see any horribly weird things, please let me know :-)

I think that it it would be nice splitting the main.rs file into separate parts about now. But I'm not sure how and where to start. That might be a later issue :-)

I have yet to test if the authentication works as expected. I would like to do that before it is merged.